### PR TITLE
Require Werkzeug version compatible with Flask==2.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tenacity==8.2.2
 Flask==2.2.3
+Werkzeug<3.0.0
 matplotlib==3.7.1
 numpy==1.24.2
 openai==0.27.0


### PR DESCRIPTION
Added an additional requirement for the library Werkzeug to avoid errors when starting web server. Without this requirement I got Werkzeug 3.x which doesn't play nice with Flask==2.2.3.